### PR TITLE
Support updating RRAs via API

### DIFF
--- a/misc/dbinit.sh
+++ b/misc/dbinit.sh
@@ -19,7 +19,7 @@ DROP TABLE IF EXISTS searchresults;
 DROP TABLE IF EXISTS interlinks;
 CREATE TABLE rra (
 	rraid SERIAL PRIMARY KEY,
-	service TEXT NOT NULL UNIQUE,
+	service TEXT NOT NULL,
 	ari TEXT NOT NULL,
 	api TEXT NOT NULL,
 	afi TEXT NOT NULL,
@@ -40,7 +40,9 @@ CREATE TABLE rra (
 	ifp TEXT NOT NULL,
 	datadefault TEXT NOT NULL,
 	lastupdated TIMESTAMP WITH TIME ZONE NOT NULL,
-	raw JSON NOT NULL
+	lastmodified TIMESTAMP WITH TIME ZONE NOT NULL,
+	raw JSON NOT NULL,
+	UNIQUE(service, lastmodified)
 );
 CREATE TABLE risk (
 	rraid INTEGER REFERENCES rra (rraid),

--- a/python/pyservicelib/pyservicelib/rra.py
+++ b/python/pyservicelib/pyservicelib/rra.py
@@ -34,3 +34,15 @@ def get_risks():
         err = 'Request error: response {}'.format(r.status_code)
         raise search.SLIBException(err)
     return json.loads(r.text)
+
+# Submits an RRA to be updated via the API, rradict should be a dict
+# representation of the RRA; the RRA information itself should be stored
+# in a 'details' struct there, and it should also have a lastmodified
+# element that is the lastmodified timestamp from the RRA
+def update_rra(rradict):
+    u = cfg.config.apiurl() + '/rra/update'
+    payload = {'rra': json.dumps(rradict)}
+    r = requests.post(u, data=payload, verify=cfg.config.sslverify)
+    if r.status_code != requests.codes.ok:
+        err = 'Request error: response {}'.format(r.status_code)
+        raise search.SLIBException(err)

--- a/src/serviceapi/rra.go
+++ b/src/serviceapi/rra.go
@@ -84,7 +84,11 @@ func serviceRisks(rw http.ResponseWriter, req *http.Request) {
 	op := opContext{}
 	op.newContext(dbconn, false, req.RemoteAddr)
 
-	rows, err := op.Query(`SELECT rraid FROM rra`)
+	rows, err := op.Query(`SELECT rraid FROM rra x
+		WHERE lastmodified = (
+			SELECT MAX(lastmodified) FROM rra y
+			WHERE x.service = y.service
+		)`)
 	if err != nil {
 		op.logf(err.Error())
 		http.Error(rw, err.Error(), 500)

--- a/src/serviceapi/rra.go
+++ b/src/serviceapi/rra.go
@@ -161,6 +161,65 @@ func serviceGetRRARisk(rw http.ResponseWriter, req *http.Request) {
 	fmt.Fprintf(rw, string(buf))
 }
 
+// Read incoming RRA and update database as required. This can result in a
+// new RRA being added, or an existing RRA being updated.
+func serviceUpdateRRA(rw http.ResponseWriter, req *http.Request) {
+	req.ParseMultipartForm(10000000)
+
+	rawrra := req.FormValue("rra")
+	if rawrra == "" {
+		logf("no rra parameter in update request")
+		http.Error(rw, "no rra parameter in update request", 500)
+		return
+	}
+
+	op := opContext{}
+	op.newContext(dbconn, false, req.RemoteAddr)
+
+	// XXX Use the same import function we use in the RRA importer for now.
+	// This can be cleaned up once the RRA importer is removed and the POST
+	// functionality for RRAs is being used exclusively.
+	var (
+		nrra    rraESData
+		rraList []rraESData
+	)
+	err := json.Unmarshal([]byte(rawrra), &nrra.rra)
+	if err != nil {
+		logf(err.Error())
+		http.Error(rw, err.Error(), 500)
+		return
+	}
+	err = json.Unmarshal([]byte(rawrra), &nrra.raw)
+	if err != nil {
+		logf(err.Error())
+		http.Error(rw, err.Error(), 500)
+		return
+	}
+	err = nrra.rra.validate()
+	if err != nil {
+		logf(err.Error())
+		http.Error(rw, err.Error(), 500)
+		return
+	}
+	rraList = append(rraList, nrra)
+
+	err = dbUpdateRRAs(rraList)
+	if err != nil {
+		op.logf(err.Error())
+		http.Error(rw, err.Error(), 500)
+		return
+	}
+
+	ur := slib.RRAUpdateResponse{OK: true}
+	buf, err := json.Marshal(&ur)
+	if err != nil {
+		op.logf(err.Error())
+		http.Error(rw, err.Error(), 500)
+		return
+	}
+	fmt.Fprintf(rw, string(buf))
+}
+
 // API entry point to retrieve specific RRA details
 func serviceGetRRA(rw http.ResponseWriter, req *http.Request) {
 	req.ParseForm()

--- a/src/serviceapi/rra.go
+++ b/src/serviceapi/rra.go
@@ -251,7 +251,10 @@ func serviceRRAs(rw http.ResponseWriter, req *http.Request) {
 	op.newContext(dbconn, false, req.RemoteAddr)
 
 	rows, err := op.Query(`SELECT rraid, service, datadefault
-		FROM rra`)
+		FROM rra x WHERE lastmodified = (
+			SELECT MAX(lastmodified) FROM rra y WHERE
+			x.service = y.service
+		)`)
 	if err != nil {
 		op.logf(err.Error())
 		http.Error(rw, err.Error(), 500)

--- a/src/serviceapi/serviceapi.go
+++ b/src/serviceapi/serviceapi.go
@@ -789,6 +789,7 @@ func main() {
 	s.HandleFunc("/rras", serviceRRAs).Methods("GET")
 	s.HandleFunc("/risks", serviceRisks).Methods("GET")
 	s.HandleFunc("/rra/id", serviceGetRRA).Methods("GET")
+	s.HandleFunc("/rra/update", serviceUpdateRRA).Methods("POST")
 	s.HandleFunc("/rra/risk", serviceGetRRARisk).Methods("GET")
 	s.HandleFunc("/vulns/target", serviceGetVulnsTarget).Methods("GET")
 	s.HandleFunc("/legacy/vulnauto", serviceVulnAuto).Methods("GET")

--- a/src/serviceapi/serviceapi.go
+++ b/src/serviceapi/serviceapi.go
@@ -213,10 +213,14 @@ func serviceLookup(op opContext, s *slib.Service) error {
 		crp, cpp, cfp,
 		irp, ipp, ifp,
 		datadefault
-		FROM rra
+		FROM rra x
 		WHERE rraid IN (
 		SELECT rraid FROM rra_sysgroup
-		WHERE sysgroupid = $1 )`, useid)
+		WHERE sysgroupid = $1 ) AND
+		lastmodified = (
+			SELECT MAX(lastmodified) FROM rra y
+			WHERE x.service = y.service
+		)`, useid)
 	if err != nil {
 		return err
 	}

--- a/src/servicelib/api.go
+++ b/src/servicelib/api.go
@@ -59,6 +59,10 @@ type IndicatorResponse struct {
 	OK bool `json:"ok"`
 }
 
+type RRAUpdateResponse struct {
+	OK bool `json:"ok"`
+}
+
 // The response to a general service query.
 type Service struct {
 	Services    []RRAService `json:"services,omitempty"`    // Services linked from RRA table


### PR DESCRIPTION
ES RRA import process is still active, but can be removed in the future if the API update method is to be preferred.