### PR TITLE
Include AWS instances in service mapping

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 src/code.google.com
 src/github.com
 src/gopkg.in
+src/mig.ninja
 bin/
 pkg/
 python/pyservicelib/build

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 src/code.google.com
 src/github.com
+src/gopkg.in
 bin/
 pkg/
 python/pyservicelib/build

--- a/Makefile
+++ b/Makefile
@@ -4,15 +4,15 @@ GO = GOPATH=$(shell pwd):$(shell go env GOROOT)/bin go
 all: $(TARGETS)
 
 depends:
-	$(GO) get github.com/mattbaird/elastigo
-	$(GO) get github.com/montanaflynn/stats
-	$(GO) get github.com/lib/pq
-	$(GO) get code.google.com/p/gcfg
-	$(GO) get github.com/gorilla/context
-	$(GO) get github.com/gorilla/mux
-	$(GO) get code.google.com/p/go-uuid/uuid
-	$(GO) get github.com/jvehent/gozdef
-	$(GO) get github.com/ameihm0912/http-observatory-go
+	$(GO) get -u github.com/mattbaird/elastigo
+	$(GO) get -u github.com/montanaflynn/stats
+	$(GO) get -u github.com/lib/pq
+	$(GO) get -u gopkg.in/gcfg.v1
+	$(GO) get -u github.com/gorilla/context
+	$(GO) get -u github.com/gorilla/mux
+	$(GO) get -u github.com/pborman/uuid
+	$(GO) get -u github.com/jvehent/gozdef
+	$(GO) get -u github.com/ameihm0912/http-observatory-go
 
 servicelib:
 	$(GO) install servicelib

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-TARGETS = servicelib serviceapi
+TARGETS = servicelib serviceapi migindicators
 GO = GOPATH=$(shell pwd):$(shell go env GOROOT)/bin go
 
 all: $(TARGETS)
@@ -13,12 +13,16 @@ depends:
 	$(GO) get -u github.com/pborman/uuid
 	$(GO) get -u github.com/jvehent/gozdef
 	$(GO) get -u github.com/ameihm0912/http-observatory-go
+	$(GO) get -u mig.ninja/mig
 
 servicelib:
 	$(GO) install servicelib
 
 serviceapi:
 	$(GO) install serviceapi
+
+migindicators:
+	$(GO) install migindicators
 
 clean:
 	rm -f bin/*

--- a/etc/serviceapi.conf
+++ b/etc/serviceapi.conf
@@ -31,3 +31,6 @@ eshost = escomphost:9200
 index = complianceitems
 scoringbatchsize = 25
 scoreevery = 5m
+
+[awsmeta]
+metafile = ./ec2output.json

--- a/etc/serviceapi.conf
+++ b/etc/serviceapi.conf
@@ -11,6 +11,7 @@ database = servicemap
 [interlink]
 rulepath = ./interlink.rules
 runevery = 10m
+awsstripdnssuffixlist = .ec2.internal
 
 [rra]
 eshost = esrrahost:9200

--- a/etc/serviceapi.conf
+++ b/etc/serviceapi.conf
@@ -34,3 +34,4 @@ scoreevery = 5m
 
 [awsmeta]
 metafile = ./ec2output.json
+lifetime = 4h

--- a/misc/dbinit.sh
+++ b/misc/dbinit.sh
@@ -7,6 +7,7 @@ $psql << EOF
 DROP TABLE IF EXISTS importcomphostcfg;
 DROP TABLE IF EXISTS vulnscore;
 DROP TABLE IF EXISTS vulnstatus;
+DROP TABLE IF EXISTS migstatus;
 DROP TABLE IF EXISTS compscore;
 DROP TABLE IF EXISTS httpobsscore;
 DROP TABLE IF EXISTS rra_sysgroup;
@@ -145,6 +146,14 @@ CREATE TABLE vulnstatus (
 	status BOOLEAN NOT NULL
 );
 CREATE INDEX ON vulnstatus (assetid);
+CREATE TABLE migstatus (
+	statusid SERIAL PRIMARY KEY,
+	timestamp TIMESTAMP WITH TIME ZONE NOT NULL,
+	assetid INTEGER REFERENCES asset (assetid),
+	version TEXT NOT NULL,
+	env JSON,
+	tags JSON
+);
 CREATE TABLE importcomphostcfg (
 	exid SERIAL PRIMARY KEY,
 	hostmatch TEXT NOT NULL UNIQUE

--- a/misc/dbinit.sh
+++ b/misc/dbinit.sh
@@ -153,6 +153,7 @@ CREATE TABLE interlinks (
 	ruleid SERIAL PRIMARY KEY,
 	ruletype INTEGER NOT NULL,
 	srchostmatch TEXT,
+	srcawssqlmatch TEXT,
 	srcsysgroupmatch TEXT,
 	destsysgroupmatch TEXT,
 	destservicematch TEXT,

--- a/misc/dbinit.sh
+++ b/misc/dbinit.sh
@@ -11,6 +11,7 @@ DROP TABLE IF EXISTS compscore;
 DROP TABLE IF EXISTS httpobsscore;
 DROP TABLE IF EXISTS rra_sysgroup;
 DROP TABLE IF EXISTS asset;
+DROP TABLE IF EXISTS assetawsmeta;
 DROP TABLE IF EXISTS assetowners;
 DROP TABLE IF EXISTS risk;
 DROP TABLE IF EXISTS rra;
@@ -65,6 +66,20 @@ CREATE TABLE assetowners (
 	operator TEXT NOT NULL,
 	UNIQUE (team, operator)
 );
+CREATE TABLE assetawsmeta (
+	assetawsmetaid SERIAL PRIMARY KEY,
+	accountid TEXT NOT NULL,
+	accountname TEXT NOT NULL,
+	region TEXT NOT NULL,
+	instancetype TEXT NOT NULL,
+	instanceid TEXT NOT NULL,
+	public_ip INET,
+	private_ip INET,
+	private_dns TEXT,
+	public_dns TEXT,
+	attributes JSON,
+	lastupdated TIMESTAMP WITH TIME ZONE NOT NULL
+);
 CREATE TABLE asset (
 	assetid SERIAL PRIMARY KEY,
 	assettype TEXT NOT NULL,
@@ -72,6 +87,7 @@ CREATE TABLE asset (
 	website TEXT,
 	sysgroupid INTEGER REFERENCES sysgroup (sysgroupid),
 	ownerid INTEGER REFERENCES assetowners (ownerid),
+	assetawsmetaid INTEGER REFERENCES assetawsmeta (assetawsmetaid),
 	v2boverride TEXT,
 	comment TEXT,
 	dynamic BOOLEAN NOT NULL,

--- a/misc/dbinit.sh
+++ b/misc/dbinit.sh
@@ -77,7 +77,7 @@ CREATE TABLE assetawsmeta (
 	private_ip INET,
 	private_dns TEXT,
 	public_dns TEXT,
-	attributes JSON,
+	tags JSON,
 	lastupdated TIMESTAMP WITH TIME ZONE NOT NULL
 );
 CREATE TABLE asset (

--- a/src/migindicators/main.go
+++ b/src/migindicators/main.go
@@ -1,0 +1,120 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+//
+// Contributor:
+// - Aaron Meihm ameihm@mozilla.com
+
+package main
+
+import (
+	"crypto/tls"
+	"encoding/json"
+	"fmt"
+	"mig.ninja/mig"
+	"mig.ninja/mig/client"
+	"net/http"
+	"net/url"
+	"os"
+	"path"
+	slib "servicelib"
+)
+
+// Small program to extract MIG agent information from the API and push
+// the details into serviceapi as an indicator
+
+const agentTarget = "status='online'"
+
+var postOut string
+var noVerify bool
+
+func agentToIndicator(a mig.Agent) (ret slib.Indicator, err error) {
+	ret.Host = a.Name
+	ret.Class = "mig"
+	ret.MIG.MIGHostname = a.Name
+	ret.MIG.MIGVersion = a.Version
+	ret.MIG.Tags = a.Tags
+	ret.MIG.Environment = a.Env
+	return
+}
+
+func sendIndicators(indparam slib.IndicatorParams) error {
+	if postOut == "-" {
+		for _, x := range indparam.Indicators {
+			buf, err := json.Marshal(&x)
+			if err != nil {
+				fmt.Fprintf(os.Stderr, "error marshaling indicator: %v\n", err)
+				continue
+			}
+			fmt.Printf("%v\n", string(buf))
+		}
+		return nil
+	}
+	buf, err := json.Marshal(&indparam)
+	if err != nil {
+		return err
+	}
+	tcfg := &http.Transport{}
+	if noVerify {
+		tcfg.TLSClientConfig = &tls.Config{InsecureSkipVerify: true}
+	}
+	clnt := http.Client{Transport: tcfg}
+	form := url.Values{}
+	form.Add("params", string(buf))
+	resp, err := clnt.PostForm(postOut, form)
+	if err != nil {
+		return err
+	}
+	if resp.StatusCode != 200 {
+		return fmt.Errorf("request failed: %v", resp.Status)
+	}
+	return nil
+}
+
+func main() {
+	var cconf client.Configuration
+
+	if len(os.Args) != 2 {
+		fmt.Printf("usage: %v [- | indicator_post_url]\n", os.Args[0])
+		os.Exit(1)
+	}
+	postOut = os.Args[1]
+
+	dbg := os.Getenv("DEBUG")
+	if dbg != "" {
+		noVerify = true
+	}
+
+	confpath := path.Join(client.FindHomedir(), ".migrc")
+	cconf, err := client.ReadConfiguration(confpath)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "error: %v\n", err)
+		os.Exit(1)
+	}
+
+	cli, err := client.NewClient(cconf, "migindicators")
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "error: %v\n", err)
+		os.Exit(1)
+	}
+
+	agents, err := cli.EvaluateAgentTarget(agentTarget)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "error: %v\n", err)
+		os.Exit(1)
+	}
+	var indparam slib.IndicatorParams
+	for _, agt := range agents {
+		ind, err := agentToIndicator(agt)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "error converting agent to indicator: %v", err)
+			continue
+		}
+		indparam.Indicators = append(indparam.Indicators, ind)
+	}
+	err = sendIndicators(indparam)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "error: %v\n", err)
+		os.Exit(1)
+	}
+}

--- a/src/serviceapi/importawsmeta.go
+++ b/src/serviceapi/importawsmeta.go
@@ -1,0 +1,102 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+//
+// Contributor:
+// - Aaron Meihm ameihm@mozilla.com
+
+package main
+
+import (
+	"encoding/json"
+	"io/ioutil"
+	slib "servicelib"
+)
+
+// Handles peridically importing AWS instance metadata and associating it
+// with known assets
+
+func processAWSInstanceMeta(mi slib.AWSInstanceMeta) error {
+	op := opContext{}
+	op.newContext(dbconn, false, "importawsmeta")
+
+	tbuf, err := json.Marshal(mi.Tags)
+	if err != nil {
+		return err
+	}
+	_, err = op.Exec(`INSERT INTO assetawsmeta
+		(accountid, accountname, region, instancetype,
+		instanceid, public_ip, private_ip, private_dns,
+		public_dns, attributes, lastupdated)
+		SELECT $1, $2, $3, $4,
+		$5, $6, $7, $8,
+		$9, $10, now()
+		WHERE NOT EXISTS (
+			SELECT 1 FROM assetawsmeta WHERE
+			accountid = $11 AND
+			instanceid = $12
+		)`, mi.AWSAccountID, mi.AWSAccountName, mi.Region,
+		mi.InstanceType, mi.InstanceID, mi.PublicIP,
+		mi.PrivateIP, mi.PrivateDNS, mi.PublicDNS, tbuf,
+		mi.AWSAccountID, mi.InstanceID)
+	if err != nil {
+		return err
+	}
+
+	_, err = op.Exec(`UPDATE assetawsmeta
+		SET accountname = $1,
+		region = $2,
+		instancetype = $3,
+		public_ip = $4,
+		private_ip = $5,
+		private_dns = $6,
+		public_dns = $7,
+		attributes = $8,
+		lastupdated = now()
+		WHERE accountid = $9 AND
+		instanceid = $10`, mi.AWSAccountName,
+		mi.Region, mi.InstanceType, mi.PublicIP,
+		mi.PrivateIP, mi.PrivateDNS,
+		mi.PublicDNS, tbuf, mi.AWSAccountID,
+		mi.InstanceID)
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
+func processAWSMeta(m slib.AWSMeta) error {
+	for _, x := range m.Instances {
+		err := processAWSInstanceMeta(x)
+		if err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func getAWSMeta() (ret slib.AWSMeta, err error) {
+	buf, err := ioutil.ReadFile(cfg.AWSMeta.MetaFile)
+	if err != nil {
+		return
+	}
+	err = json.Unmarshal(buf, &ret)
+	return
+}
+
+// Entry point for AWS metadata import routine
+func importAWSMeta() {
+	defer func() {
+		if e := recover(); e != nil {
+			logf("error in aws metadata import routine: %v", e)
+		}
+	}()
+	meta, err := getAWSMeta()
+	if err != nil {
+		panic(err)
+	}
+	err = processAWSMeta(meta)
+	if err != nil {
+		panic(err)
+	}
+}

--- a/src/serviceapi/importawsmeta.go
+++ b/src/serviceapi/importawsmeta.go
@@ -27,7 +27,7 @@ func processAWSInstanceMeta(mi slib.AWSInstanceMeta) error {
 	_, err = op.Exec(`INSERT INTO assetawsmeta
 		(accountid, accountname, region, instancetype,
 		instanceid, public_ip, private_ip, private_dns,
-		public_dns, attributes, lastupdated)
+		public_dns, tags, lastupdated)
 		SELECT $1, $2, $3, $4,
 		$5, $6, $7, $8,
 		$9, $10, now()
@@ -51,7 +51,7 @@ func processAWSInstanceMeta(mi slib.AWSInstanceMeta) error {
 		private_ip = $5,
 		private_dns = $6,
 		public_dns = $7,
-		attributes = $8,
+		tags = $8,
 		lastupdated = now()
 		WHERE accountid = $9 AND
 		instanceid = $10`, mi.AWSAccountName,

--- a/src/serviceapi/indicator.go
+++ b/src/serviceapi/indicator.go
@@ -8,6 +8,7 @@
 package main
 
 import (
+	"encoding/json"
 	"fmt"
 	slib "servicelib"
 )
@@ -15,18 +16,39 @@ import (
 // Validate an indicator and update the database
 func processIndicator(op opContext, ind slib.Indicator) (err error) {
 	// Verify it's a class we expect, currently only vuln
-	if ind.Class != "vuln" {
-		return fmt.Errorf("unknown indicator class")
-	}
-	_, err = op.Exec(`INSERT INTO vulnstatus
+	if ind.Class == "vuln" {
+		_, err = op.Exec(`INSERT INTO vulnstatus
 		(timestamp, assetid, checktype, status)
 		VALUES (now(),
 		(SELECT assetid FROM asset WHERE
 		lower(hostname) = lower($1) AND
 		assettype = 'host'),
 		$2, $3)`, ind.Host, ind.CheckType, ind.Status)
-	if err != nil {
-		return err
+		if err != nil {
+			return err
+		}
+		return nil
+	} else if ind.Class == "mig" {
+		ebuf, err := json.Marshal(&ind.MIG.Environment)
+		if err != nil {
+			return err
+		}
+		tbuf, err := json.Marshal(&ind.MIG.Tags)
+		if err != nil {
+			return err
+		}
+		_, err = op.Exec(`INSERT INTO migstatus
+		(timestamp, assetid, version, tags, env)
+		VALUES (now(),
+		(SELECT assetid FROM asset WHERE
+		lower(hostname) = lower($1) AND
+		assettype = 'host'),
+		$2, $3, $4)`, ind.MIG.MIGHostname, ind.MIG.MIGVersion,
+			string(tbuf), string(ebuf))
+		if err != nil {
+			return err
+		}
+		return nil
 	}
-	return nil
+	return fmt.Errorf("unknown indicator class")
 }

--- a/src/serviceapi/interlink.go
+++ b/src/serviceapi/interlink.go
@@ -374,6 +374,17 @@ func interlinkAssociateAWSPrivateDNS(op opContext) error {
 	if err != nil {
 		return err
 	}
+	slist := strings.Split(cfg.Interlink.AWSStripDNSSuffixList, " ")
+	for _, x := range slist {
+		xv := "%" + x
+		_, err = op.Exec(`UPDATE asset x
+		SET assetawsmetaid = (SELECT assetawsmetaid FROM assetawsmeta y
+		WHERE x.hostname = substring(y.private_dns from '[^\.]*')
+		AND y.private_dns LIKE $1)`, xv)
+		if err != nil {
+			return err
+		}
+	}
 	return nil
 }
 

--- a/src/serviceapi/interlink.go
+++ b/src/serviceapi/interlink.go
@@ -415,7 +415,12 @@ func interlinkAssociateAWSPrivateDNS(op opContext) error {
 	}
 	_, err = op.Exec(`UPDATE asset x
 		SET assetawsmetaid = (SELECT assetawsmetaid FROM assetawsmeta y
-		WHERE x.hostname = y.private_dns)`)
+		WHERE x.hostname = y.private_dns) WHERE
+		assetid IN (
+			SELECT assetid FROM asset a
+			JOIN assetawsmeta b ON
+			a.hostname = b.private_dns
+		)`)
 	if err != nil {
 		return err
 	}
@@ -425,7 +430,13 @@ func interlinkAssociateAWSPrivateDNS(op opContext) error {
 		_, err = op.Exec(`UPDATE asset x
 		SET assetawsmetaid = (SELECT assetawsmetaid FROM assetawsmeta y
 		WHERE x.hostname = substring(y.private_dns from '[^\.]*')
-		AND y.private_dns LIKE $1)`, xv)
+		AND y.private_dns LIKE $1) WHERE
+		assetid IN (
+			SELECT assetid FROM asset a
+			JOIN assetawsmeta b ON
+			a.hostname = substring(b.private_dns from '[^\.]*') AND
+			b.private_dns LIKE $2
+		)`, xv, xv)
 		if err != nil {
 			return err
 		}

--- a/src/serviceapi/interlink.go
+++ b/src/serviceapi/interlink.go
@@ -27,7 +27,7 @@ const (
 	WEBSITE_LINK_SYSGROUP
 	HOST_OWNERSHIP
 	OWNER_ADD
-	ASSOCIATE_AWS_PRIVATEDNS
+	ASSOCIATE_AWS
 	HOST_AWSSQL_LINK_SYSGROUP
 )
 
@@ -401,11 +401,11 @@ func interlinkSysGroupServiceLink(op opContext) error {
 	return nil
 }
 
-func interlinkAssociateAWSPrivateDNS(op opContext) error {
+func interlinkAssociateAWS(op opContext) error {
 	var v int
 	// Just run it once if the rule is present in the rule set
 	err := op.QueryRow(`SELECT 1 FROM interlinks WHERE
-		ruletype = $1`, ASSOCIATE_AWS_PRIVATEDNS).Scan(&v)
+		ruletype = $1`, ASSOCIATE_AWS).Scan(&v)
 	if err != nil {
 		if err == sql.ErrNoRows {
 			return nil
@@ -523,7 +523,7 @@ func interlinkRunRules() error {
 		}
 		return err
 	}
-	err = interlinkAssociateAWSPrivateDNS(op)
+	err = interlinkAssociateAWS(op)
 	if err != nil {
 		e := op.rollback()
 		if e != nil {
@@ -639,7 +639,7 @@ func interlinkLoadRules() error {
 			valid = true
 		} else if len(tokens) == 3 && tokens[0] == "associate" && tokens[1] == "aws" &&
 			tokens[2] == "privatedns" {
-			nr.ruletype = ASSOCIATE_AWS_PRIVATEDNS
+			nr.ruletype = ASSOCIATE_AWS
 			valid = true
 		}
 		if !valid {
@@ -749,7 +749,7 @@ func interlinkLoadRules() error {
 				}
 				return err
 			}
-		case ASSOCIATE_AWS_PRIVATEDNS:
+		case ASSOCIATE_AWS:
 			_, err = op.Exec(`INSERT INTO interlinks (ruletype)
 				VALUES ($1)`, x.ruletype)
 			if err != nil {

--- a/src/serviceapi/serviceapi.go
+++ b/src/serviceapi/serviceapi.go
@@ -125,6 +125,9 @@ type Config struct {
 		ScoringBatchSize int
 		ScoreEvery       string
 	}
+	AWSMeta struct {
+		MetaFile string
+	}
 }
 
 func (c *Config) validate() error {
@@ -748,6 +751,14 @@ func main() {
 		for {
 			importRRA()
 			time.Sleep(15 * time.Minute)
+		}
+	}()
+	// Spawn AWS metadata import process
+	go func() {
+		logf("spawning aws metadata import routine")
+		for {
+			importAWSMeta()
+			time.Sleep(15 * time.Second)
 		}
 	}()
 	// Spawn compliance host import process

--- a/src/serviceapi/serviceapi.go
+++ b/src/serviceapi/serviceapi.go
@@ -622,6 +622,12 @@ func dynAssetManager() {
 			rows.Close()
 			panic(err)
 		}
+		_, err = op.Exec(`DELETE FROM migstatus
+				WHERE assetid = $1`, assetid)
+		if err != nil {
+			rows.Close()
+			panic(err)
+		}
 		_, err = op.Exec(`DELETE FROM httpobsscore
 				WHERE assetid = $1`, assetid)
 		if err != nil {

--- a/src/serviceapi/serviceapi.go
+++ b/src/serviceapi/serviceapi.go
@@ -599,34 +599,44 @@ func dynAssetManager() {
 		var assetid int
 		err = rows.Scan(&assetid)
 		if err != nil {
+			rows.Close()
 			panic(err)
 		}
 		logf("removing asset %v", assetid)
 		_, err = op.Exec(`DELETE FROM compscore
 				WHERE assetid = $1`, assetid)
 		if err != nil {
+			rows.Close()
 			panic(err)
 		}
 		_, err = op.Exec(`DELETE FROM vulnscore
 				WHERE assetid = $1`, assetid)
 		if err != nil {
+			rows.Close()
 			panic(err)
 		}
 		_, err = op.Exec(`DELETE FROM vulnstatus
 				WHERE assetid = $1`, assetid)
 		if err != nil {
+			rows.Close()
 			panic(err)
 		}
 		_, err = op.Exec(`DELETE FROM httpobsscore
 				WHERE assetid = $1`, assetid)
 		if err != nil {
+			rows.Close()
 			panic(err)
 		}
 		_, err = op.Exec(`DELETE FROM asset
 				WHERE assetid = $1`, assetid)
 		if err != nil {
+			rows.Close()
 			panic(err)
 		}
+	}
+	err = rows.Err()
+	if err != nil {
+		panic(err)
 	}
 
 	// Drop any AWS instance metadata that we have not seen since configured
@@ -651,13 +661,19 @@ func dynAssetManager() {
 		_, err = op.Exec(`UPDATE asset SET assetawsmetaid = NULL
 			WHERE assetawsmetaid = $1`, metaid)
 		if err != nil {
+			rows.Close()
 			panic(err)
 		}
 		_, err = op.Exec(`DELETE FROM assetawsmeta WHERE
 			assetawsmetaid = $1`, metaid)
 		if err != nil {
+			rows.Close()
 			panic(err)
 		}
+	}
+	err = rows.Err()
+	if err != nil {
+		panic(err)
 	}
 }
 

--- a/src/serviceapi/serviceapi.go
+++ b/src/serviceapi/serviceapi.go
@@ -102,8 +102,9 @@ type Config struct {
 		Database string
 	}
 	Interlink struct {
-		RulePath string
-		RunEvery string
+		RulePath              string
+		RunEvery              string
+		AWSStripDNSSuffixList string
 	}
 	RRA struct {
 		ESHost string

--- a/src/servicelib/api.go
+++ b/src/servicelib/api.go
@@ -48,10 +48,24 @@ type IndicatorParams struct {
 
 // Describes indicator information
 type Indicator struct {
-	Host      string `json:"host,omitempty"`
-	Class     string `json:"class"`
+	// Common attributes amongst all classes
+	Host string `json:"host,omitempty"` // Hostname of system
+
+	Class string `json:"class"` // Indicator class
+
+	// Used for "vuln" class indicators
 	CheckType string `json:"checktype"`
 	Status    bool   `json:"status"`
+
+	// Used for "migagent" class indicators
+	MIG IndicatorMIG `json:"mig"`
+}
+
+type IndicatorMIG struct {
+	MIGHostname string      `json:"hostname"`
+	MIGVersion  string      `json:"version"`
+	Tags        interface{} `json:"tags"`
+	Environment interface{} `json:"environment"`
 }
 
 // The response to an indicator request

--- a/src/servicelib/aws.go
+++ b/src/servicelib/aws.go
@@ -1,0 +1,28 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+//
+// Contributor:
+// - Aaron Meihm ameihm@mozilla.com
+
+package servicelib
+
+// Describes format of AWS metadata returned by metadata service
+type AWSMeta struct {
+	Instances []AWSInstanceMeta `json:"instances"`
+}
+
+type AWSInstanceMeta struct {
+	AWSAccountID   string      `json:"aws_account_id"`
+	AWSAccountName string      `json:"aws_account_name"`
+	InstanceID     string      `json:"id"`
+	ImageID        string      `json:"image_id"`
+	InstanceType   string      `json:"instance_type"`
+	PublicIP       string      `json:"ip_address"`
+	PrivateIP      string      `json:"private_ip_address"`
+	Platform       string      `json:"platform"`
+	PrivateDNS     string      `json:"private_dns_name"`
+	PublicDNS      string      `json:"public_dns_name"`
+	Region         string      `json:"region"`
+	Tags           interface{} `json:"tags"`
+}


### PR DESCRIPTION
Utilizes correlation using external information (e.g., MIG metadata queries, AWS API queries) to include instances in service profiles