### PR TITLE
Adjustments to automated risk calculation

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -11,7 +11,7 @@ depends:
 	$(GO) get -u github.com/gorilla/context
 	$(GO) get -u github.com/gorilla/mux
 	$(GO) get -u github.com/pborman/uuid
-	$(GO) get -u github.com/jvehent/gozdef
+	$(GO) get -u github.com/ameihm0912/gozdef
 	$(GO) get -u github.com/ameihm0912/http-observatory-go
 	$(GO) get -u mig.ninja/mig
 	$(GO) get -u mig.ninja/mig/client

--- a/misc/dbinit.sh
+++ b/misc/dbinit.sh
@@ -124,7 +124,8 @@ CREATE TABLE vulnscore (
 	maxcount INTEGER DEFAULT 0 NOT NULL,
 	highcount INTEGER DEFAULT 0 NOT NULL,
 	mediumcount INTEGER DEFAULT 0 NOT NULL,
-	lowcount INTEGER DEFAULT 0 NOT NULL
+	lowcount INTEGER DEFAULT 0 NOT NULL,
+	likelihoodindicator INTEGER DEFAULT 0 NOT NULL
 );
 CREATE INDEX ON vulnscore (assetid, timestamp DESC);
 CREATE TABLE httpobsscore (

--- a/src/serviceapi/hostmeta.go
+++ b/src/serviceapi/hostmeta.go
@@ -118,12 +118,13 @@ func hostAddVuln(op opContext, h *slib.Host) error {
 	}
 
 	err = op.QueryRow(`SELECT maxcount, highcount,
-		mediumcount, lowcount, timestamp
+		mediumcount, lowcount, likelihoodindicator, timestamp
 		FROM vulnscore WHERE assetid = $1 AND
 		timestamp > now() - interval '168 hours'
 		ORDER BY timestamp DESC
 		LIMIT 1`, h.ID).Scan(&h.VulnStatus.Maximum,
-		&h.VulnStatus.High, &h.VulnStatus.Medium, &h.VulnStatus.Low, &tstamp)
+		&h.VulnStatus.High, &h.VulnStatus.Medium, &h.VulnStatus.Low,
+		&h.VulnStatus.LikelihoodIndicator, &tstamp)
 	if err != nil {
 		if err == sql.ErrNoRows {
 			return nil

--- a/src/serviceapi/risk.go
+++ b/src/serviceapi/risk.go
@@ -86,12 +86,9 @@ func riskComplianceScenario(op opContext, rs *slib.RRAServiceRisk,
 
 func riskVulnerabilityScenario(op opContext, rs *slib.RRAServiceRisk,
 	src slib.RRAAttribute, desc string) error {
-	// The score here will range from 1 to 4, and will be set to the
-	// score associated with the highest vulnerability impact value
-	// identified on the hosts in scope. For example, a single maximum
-	// impact vulnerability will result in a probability score of 4.0.
-	//
-	// This could probably be changed to be a little more lenient.
+	// Utilize the likelihood indicator set with the vulnerabilty score
+	// as the probability for the calculation; this will range from
+	// 1 to 4.
 	datacount := 0
 	hostcount := 0
 	highest := 1.0
@@ -102,18 +99,8 @@ func riskVulnerabilityScenario(op opContext, rs *slib.RRAServiceRisk,
 				continue
 			}
 			datacount++
-			// If we have already seen a max impact issue, just break
-			if highest == 4.0 {
-				break
-			}
-			if y.VulnStatus.Medium > 0 && highest < 2.0 {
-				highest = 2.0
-			}
-			if y.VulnStatus.High > 0 && highest < 3.0 {
-				highest = 3.0
-			}
-			if y.VulnStatus.Maximum > 0 && highest < 4.0 {
-				highest = 4.0
+			if float64(y.VulnStatus.LikelihoodIndicator) > highest {
+				highest = float64(y.VulnStatus.LikelihoodIndicator)
 			}
 		}
 	}

--- a/src/serviceapi/risk.go
+++ b/src/serviceapi/risk.go
@@ -162,14 +162,14 @@ func riskHTTPObsScenario(op opContext, rs *slib.RRAServiceRisk,
 			}
 			havecnt++
 			var uval int
+			// If the site scores 75 or higher, treat is as LOW.
+			// probability. The observatory does not provide a likelihood
+			// indicator directly. If the score is below 75, treat
+			// it as MEDIUM.
 			if y.HTTPObs.Score >= 75 {
 				uval = 1
-			} else if y.HTTPObs.Score >= 50 {
-				uval = 2
-			} else if y.HTTPObs.Score >= 24 {
-				uval = 3
 			} else {
-				uval = 4
+				uval = 2
 			}
 			if float64(uval) >= highest {
 				highest = float64(uval)

--- a/src/serviceapi/risk.go
+++ b/src/serviceapi/risk.go
@@ -67,6 +67,14 @@ func riskComplianceScenario(op opContext, rs *slib.RRAServiceRisk,
 		}
 	}
 
+	// Cap the maximum possible probability for compliance scenarios
+	// off at 2.0; these events do not include a likelihood indicator
+	// we will use directly but they are not considered to ever raise
+	// probability to "high" or greater
+	if scr > 2.0 {
+		scr = 2.0
+	}
+
 	newscen := slib.RiskScenario{
 		Name:        "Compliance scenario for " + desc,
 		Impact:      src.Impact,

--- a/src/serviceapi/risk.go
+++ b/src/serviceapi/risk.go
@@ -47,8 +47,8 @@ func riskComplianceScenario(op opContext, rs *slib.RRAServiceRisk,
 			}
 		}
 	}
-	// If totalcnt is zero, we didn't have any data points.
-	if totalcnt == 0 {
+	// If totalcnt is zero, or the Impact value is 0, we didn't have any data points.
+	if totalcnt == 0 || src.Impact == 0 {
 		ndp := slib.RiskScenario{
 			Name:     "Compliance scenario for " + desc,
 			NoData:   true,
@@ -112,7 +112,7 @@ func riskVulnerabilityScenario(op opContext, rs *slib.RRAServiceRisk,
 			}
 		}
 	}
-	if datacount == 0 {
+	if datacount == 0 || src.Impact == 0 {
 		newscan := slib.RiskScenario{
 			Name:     "Vulnerability scenario for " + desc,
 			Coverage: "none",

--- a/src/serviceapi/risk.go
+++ b/src/serviceapi/risk.go
@@ -218,9 +218,17 @@ func riskRRAScenario(op opContext, rs *slib.RRAServiceRisk, src slib.RRAAttribut
 		NoData:   true,
 	}
 	if src.Impact != 0 && src.Probability != 0 {
-		newscen.Probability = src.Probability
+		// Cap the maximum probability we will use on the RRA at 2.0 (MEDIUM).
+		// Some older RRAs (and some new ones) don't have correct probability
+		// values set; once these are revisted we might be able to remove the
+		// cap but for now set it to 2.
+		if src.Probability > 2 {
+			newscen.Probability = 2
+		} else {
+			newscen.Probability = src.Probability
+		}
 		newscen.Impact = src.Impact
-		newscen.Score = src.Impact * src.Probability
+		newscen.Score = newscen.Impact * newscen.Probability
 		newscen.Coverage = "complete"
 		newscen.NoData = false
 	}

--- a/src/serviceapi/risk.go
+++ b/src/serviceapi/risk.go
@@ -311,7 +311,7 @@ func riskFinalize(op opContext, rs *slib.RRAServiceRisk) error {
 }
 
 // Determine which attributes (e.g., conf, integ, avail) from the RRA
-// we want to use was impact inputs for the risk scenarios.
+// we want to use as impact inputs for the risk scenarios.
 func riskFindHighestImpact(rs *slib.RRAServiceRisk) error {
 	rs.UsedRRAAttrib.Reputation.Impact,
 		rs.UsedRRAAttrib.Reputation.Probability = rs.RRA.HighestRiskReputation()

--- a/src/serviceapi/scorecomp.go
+++ b/src/serviceapi/scorecomp.go
@@ -10,7 +10,7 @@ package main
 import (
 	"encoding/json"
 	"fmt"
-	"github.com/jvehent/gozdef"
+	"github.com/ameihm0912/gozdef"
 	elastigo "github.com/mattbaird/elastigo/lib"
 	"time"
 )

--- a/src/serviceapi/vulns.go
+++ b/src/serviceapi/vulns.go
@@ -10,7 +10,7 @@ package main
 import (
 	"encoding/json"
 	"fmt"
-	"github.com/jvehent/gozdef"
+	"github.com/ameihm0912/gozdef"
 	elastigo "github.com/mattbaird/elastigo/lib"
 	"net/http"
 	slib "servicelib"

--- a/src/servicelib/api.go
+++ b/src/servicelib/api.go
@@ -10,7 +10,7 @@ package servicelib
 // Search types and various encapsulation used in certain API responses
 
 import (
-	"github.com/jvehent/gozdef"
+	"github.com/ameihm0912/gozdef"
 )
 
 // Parameters used for a search request.

--- a/src/servicelib/host.go
+++ b/src/servicelib/host.go
@@ -26,10 +26,11 @@ type Host struct {
 type VulnerabilityStatus struct {
 	Coverage bool `json:"coverage"` // True if we have assessment coverage
 
-	Maximum int `json:"maximum"`
-	High    int `json:"high"`
-	Medium  int `json:"medium"`
-	Low     int `json:"low"`
+	Maximum             int `json:"maximum"`
+	High                int `json:"high"`
+	Medium              int `json:"medium"`
+	Low                 int `json:"low"`
+	LikelihoodIndicator int `json:"likelihood_indicator"`
 }
 
 func (v *VulnerabilityStatus) Reset() {


### PR DESCRIPTION
Majority of metric based probability values are capped at 2 (MEDIUM). Where possible we want to use likelihood indicators being produced by the controls, this is limited to vulnerability events at this time. We also cap RRA probability values used in RRA based scenarios at MEDIUM.