### PR TITLE
Update servicerisk.html

### DIFF
--- a/python/serviceui/serviceui/templates/servicerisk.html
+++ b/python/serviceui/serviceui/templates/servicerisk.html
@@ -255,9 +255,9 @@
       "naColor": "#fffff",
       "colorStops": [
         {"val":1, "color":"#d04437"},
-        {"val":0.7, "color":"#ffd351"},
+        {"val":0.75, "color":"#ffd351"},
         {"val":0.5, "color":"#4a6785"},
-        {"val":0.2, "color":"#cccccc"},
+        {"val":0.25, "color":"#cccccc"},
         {"val":0, "color":"#ffffff"}
       ],
       leafNodeBodyGradient: function(ctx,rect,rgb) {


### PR DESCRIPTION
Fix color stops to 25%, 75% instead of 20 and 70%.
This represents the split of risk levels