### PR TITLE
reduce es query size for compliance and vuln queries

### DIFF
--- a/src/serviceapi/importcomphosts.go
+++ b/src/serviceapi/importcomphosts.go
@@ -14,7 +14,7 @@ import (
 	"regexp"
 )
 
-var esRequestMax = 1000000
+var esRequestMax = 10000
 
 func requestComplianceHosts() ([]string, error) {
 	type fieldResponse struct {

--- a/src/serviceapi/scorecomp.go
+++ b/src/serviceapi/scorecomp.go
@@ -80,7 +80,7 @@ func scoreComplianceScoreHost(hid int, h string) (err error) {
 
 	logf("scorecomp: processing %v", h)
 	template := `{
-		"size": 1000000,
+		"size": 10000,
 		"query": {
 			"bool": {
 				"must": [

--- a/src/serviceapi/scorevuln.go
+++ b/src/serviceapi/scorevuln.go
@@ -81,7 +81,7 @@ func scoreVulnScoreHost(hid int, h string) (err error) {
 
 	logf("scorevuln: processing %v", h)
 	template := `{
-		"size": 1000000,
+		"size": 10000,
 		"query": {
 			"bool": {
 				"must": [


### PR DESCRIPTION
Related to #23, this reduces the query size to an acceptable level. This
should be converted to use a proper cursor type query.