### PR TITLE
add creation of a reference service

### DIFF
--- a/serviceapi/indicator.go
+++ b/serviceapi/indicator.go
@@ -57,17 +57,23 @@ func serviceIndicator(rw http.ResponseWriter, req *http.Request) {
 		http.Error(rw, "error processing indicator", 500)
 		return
 	}
+	err = insertIndicator(op, indicator, asset, detailsbuf)
+	if err != nil {
+		op.logf(err.Error())
+		http.Error(rw, "error processing indicator", 500)
+	}
+	return
+}
+
+func insertIndicator(op opContext, indicator slib.RawIndicator, asset slib.Asset, detailsbuf []byte) error {
+	var err error
 	op.logf("adding new indicator for asset %v (%v)", asset.ID, indicator.EventSource)
 	_, err = op.Exec(`INSERT INTO indicator
 		(timestamp, event_source, likelihood_indicator, assetid, details)
 		VALUES ($1, $2, $3, $4, $5)`,
 		indicator.Timestamp, indicator.EventSource, indicator.Likelihood,
 		asset.ID, string(detailsbuf))
-	if err != nil {
-		op.logf(err.Error())
-		http.Error(rw, "error processing indicator", 500)
-		return
-	}
+	return err
 }
 
 // getAsset returns asset ID aid from the database

--- a/serviceapi/reference.go
+++ b/serviceapi/reference.go
@@ -1,0 +1,317 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+//
+// Contributor:
+// - Aaron Meihm ameihm@mozilla.com
+
+package main
+
+import (
+	"encoding/json"
+	"time"
+
+	slib "github.com/mozilla/service-map/servicelib"
+)
+
+var referenceRRA = `
+{
+	"details": {
+		"metadata": {
+			"service": "Reference service"
+		},
+		"risk": {
+			"confidentiality": {
+				"reputation": {
+					"impact": "HIGH",
+					"probability": "HIGH"
+				},
+				"finances": {
+					"impact": "HIGH",
+					"probability": "HIGH"
+				},
+				"productivity": {
+					"impact": "HIGH",
+					"probability": "HIGH"
+				}
+			},
+			"integrity": {
+				"reputation": {
+					"impact": "HIGH",
+					"probability": "HIGH"
+				},
+				"finances": {
+					"impact": "HIGH",
+					"probability": "HIGH"
+				},
+				"productivity": {
+					"impact": "HIGH",
+					"probability": "HIGH"
+				}
+			},
+			"availability": {
+				"reputation": {
+					"impact": "HIGH",
+					"probability": "HIGH"
+				},
+				"finances": {
+					"impact": "HIGH",
+					"probability": "HIGH"
+				},
+				"productivity": {
+					"impact": "HIGH",
+					"probability": "HIGH"
+				}
+			}
+		},
+		"data": {
+			"default": "confidential restricted"
+		}
+	},
+	"lastmodified": "2017-08-02T14:25:47.511Z"
+}
+`
+
+var platformVulnIndicator = `
+{
+	"asset_type": "hostname",
+	"asset_identifier": "referencehost.reference.com",
+	"zone": "reference",
+	"timestamp_utc": "2017-08-02T14:25:47.511Z",
+	"description": "scanapi vulnerability result",
+	"event_source_name": "scanapi",
+	"likelihood_indicator": "high",
+	"details": {
+		"coverage": true,
+		"maximum": 0,
+		"high": 1,
+		"medium": 6,
+		"low": 8
+	}
+}
+`
+
+var dastVulnIndicator = `
+{
+	"asset_type": "website",
+	"asset_identifier": "referencewww.reference.com",
+	"zone": "reference",
+	"timestamp_utc": "2017-08-02T14:25:47.511Z",
+	"description": "ZAP DAST scan",
+	"event_source_name": "ZAP DAST scan",
+	"likelihood_indicator": "medium",
+	"details": [
+		{
+			"name": "Cookie No HttpOnly Flag",
+			"site": "referencewww.reference.com",
+			"likelihood_indicator": "low"
+		},
+		{
+			"name": "Cross-Domain Javascript Source File Inclusion",
+			"site": "referencewww.reference.com",
+			"likelihood_indicator": "low"
+		},
+		{
+			"name": "CSP scanner: script-src unsafe-inline",
+			"site": "referencewww.reference.com",
+			"likelihood_indicator": "medium"
+		}
+	]
+}
+`
+
+var complianceIndicator = `
+{
+	"asset_type": "hostname",
+	"asset_identifier": "referencehost.reference.com",
+	"zone": "reference",
+	"timestamp_utc": "2017-08-02T14:25:47.511Z",
+	"description": "MIG compliance",
+	"event_source_name": "MIG compliance",
+	"likelihood_indicator": "medium",
+	"details": [
+		{
+			"name": "syslowaudit1",
+			"impact": "low",
+			"compliance": false
+		},
+		{
+			"name": "syshighremote1",
+			"impact": "high",
+			"compliance": true
+		},
+		{
+			"name": "sysmediumconfig1",
+			"impact": "medium",
+			"compliance": false 
+		}
+	]
+}
+`
+
+var observatoryIndicator = `
+{
+	"asset_type": "website",
+	"asset_identifier": "referencewww.reference.com",
+	"zone": "reference",
+	"timestamp_utc": "2017-08-02T14:25:47.511Z",
+	"description": "Mozilla Observatory scan",
+	"event_source_name": "Mozilla Observatory",
+	"likelihood_indicator": "medium",
+	"details": {
+		"grade": "F",
+		"tests": [
+			{
+				"name": "Content security policy",
+				"pass": false
+			},
+			{
+				"name": "Cookies",
+				"pass": true
+			},
+			{
+				"name": "HTTP Public Key Pinning",
+				"pass": false
+			},
+			{
+				"name": "X-Frame-Options",
+				"pass": false
+			},
+			{
+				"name": "Cross-origin Resource Sharing",
+				"pass": true
+			}
+		]
+	}
+}
+`
+
+func referenceUpdateIndicators() error {
+	var indicator slib.RawIndicator
+
+	op := opContext{}
+	op.newContext(dbconn, false, "reference")
+
+	// Platform vulnerability reference
+	err := json.Unmarshal([]byte(platformVulnIndicator), &indicator)
+	if err != nil {
+		return err
+	}
+	indicator.Timestamp = time.Now().UTC()
+	asset, err := assetFromIndicator(op, indicator)
+	if err != nil {
+		return err
+	}
+	detailsbuf, err := json.Marshal(indicator.Details)
+	if err != nil {
+		return err
+	}
+	err = insertIndicator(op, indicator, asset, detailsbuf)
+	if err != nil {
+		return err
+	}
+
+	// DAST vulnerability reference
+	err = json.Unmarshal([]byte(dastVulnIndicator), &indicator)
+	if err != nil {
+		return err
+	}
+	indicator.Timestamp = time.Now().UTC()
+	asset, err = assetFromIndicator(op, indicator)
+	if err != nil {
+		return err
+	}
+	detailsbuf, err = json.Marshal(indicator.Details)
+	if err != nil {
+		return err
+	}
+	err = insertIndicator(op, indicator, asset, detailsbuf)
+	if err != nil {
+		return err
+	}
+
+	// Compliance reference
+	err = json.Unmarshal([]byte(complianceIndicator), &indicator)
+	if err != nil {
+		return err
+	}
+	indicator.Timestamp = time.Now().UTC()
+	asset, err = assetFromIndicator(op, indicator)
+	if err != nil {
+		return err
+	}
+	detailsbuf, err = json.Marshal(indicator.Details)
+	if err != nil {
+		return err
+	}
+	err = insertIndicator(op, indicator, asset, detailsbuf)
+	if err != nil {
+		return err
+	}
+
+	// Observatory reference
+	err = json.Unmarshal([]byte(observatoryIndicator), &indicator)
+	if err != nil {
+		return err
+	}
+	indicator.Timestamp = time.Now().UTC()
+	asset, err = assetFromIndicator(op, indicator)
+	if err != nil {
+		return err
+	}
+	detailsbuf, err = json.Marshal(indicator.Details)
+	if err != nil {
+		return err
+	}
+	err = insertIndicator(op, indicator, asset, detailsbuf)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func referenceService() error {
+	err := referenceUpdateRRA()
+	if err != nil {
+		return err
+	}
+	err = referenceUpdateIndicators()
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
+func referenceUpdateRRA() error {
+	var jsonrra slib.RawRRA
+
+	op := opContext{}
+	op.newContext(dbconn, false, "reference")
+
+	err := json.Unmarshal([]byte(referenceRRA), &jsonrra)
+	if err != nil {
+		return err
+	}
+	err = jsonrra.Validate()
+	if err != nil {
+		return err
+	}
+	rra := jsonrra.ToRRA()
+	err = insertRRA(op, rra, []byte(referenceRRA))
+	rra.LastUpdated = time.Now().UTC()
+	return err
+}
+
+func referenceUpdate() {
+	defer func() {
+		if e := recover(); e != nil {
+			logf("error in reference update routine: %v", e)
+		}
+	}()
+
+	err := referenceService()
+	if err != nil {
+		panic(err)
+	}
+}

--- a/serviceapi/reference_test.go
+++ b/serviceapi/reference_test.go
@@ -1,0 +1,65 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+//
+// Contributor:
+// - Aaron Meihm ameihm@mozilla.com
+
+package main
+
+import (
+	"encoding/json"
+
+	"testing"
+)
+
+func TestGetReference(t *testing.T) {
+	op := opContext{}
+	op.newContext(dbconn, false, "127.0.0.1")
+
+	rra, err := getRRA(op, 3)
+	if err != nil {
+		t.Fatalf("getRRA: %v", err)
+	}
+	if rra.Name != "Reference service" {
+		t.Fatalf("getRRA: unexpected service name")
+	}
+	if rra.ConfiRepImpact != "high" {
+		t.Fatalf("getRRA: unexpected impact for reference service attribute")
+	}
+	if rra.DefData != "confidential restricted" {
+		t.Fatalf("getRRA: unexpected data classification for reference service attribute")
+	}
+
+	risk, err := riskForRRA(op, false, 3)
+	if err != nil {
+		t.Fatalf("riskForRRA: %v", err)
+	}
+	_, err = json.Marshal(risk)
+	if err != nil {
+		t.Fatalf("json.Marshal: %v", err)
+	}
+
+	// Validate some of the fields in the reference risk document
+	if risk.RRA.Name != "Reference service" {
+		t.Fatalf("riskForRRA: unexpected service name")
+	}
+
+	// We should have one asset group, named "reference"
+	if len(risk.RRA.Groups) != 1 {
+		t.Fatalf("riskForRRA: unexpected number of asset groups")
+	}
+	if risk.RRA.Groups[0].Name != "reference" {
+		t.Fatalf("riskForRRA: incorrect asset group name")
+	}
+
+	// We should have two assets in this group
+	if len(risk.RRA.Groups[0].Assets) != 2 {
+		t.Fatalf("riskForRRA: incorrect number of assets in asset group")
+	}
+
+	// We should have 5 scenarios here for the indicators provided and the derived RRA probability
+	if len(risk.Scenarios) != 5 {
+		t.Fatalf("riskForRRA: incorrect number of scenarios")
+	}
+}

--- a/serviceapi/rra.go
+++ b/serviceapi/rra.go
@@ -204,7 +204,17 @@ func serviceUpdateRRA(rw http.ResponseWriter, req *http.Request) {
 	// Convert the incoming RRA into an RRA type, and insert it into the
 	// database if required
 	rra := rawrra.ToRRA()
-	_, err = op.Exec(`INSERT INTO rra
+	err = insertRRA(op, rra, buf)
+	if err != nil {
+		op.logf(err.Error())
+		http.Error(rw, "error processing rra", 500)
+	}
+	return
+}
+
+// insertRRA inserts RRA rra into the database
+func insertRRA(op opContext, rra slib.RRA, raw []byte) error {
+	_, err := op.Exec(`INSERT INTO rra
 		(service,
 		impact_availrep, impact_availprd, impact_availfin,
 		impact_confirep, impact_confiprd, impact_confifin,
@@ -231,13 +241,9 @@ func serviceUpdateRRA(rw http.ResponseWriter, req *http.Request) {
 		rra.AvailRepProb, rra.AvailPrdProb, rra.AvailFinProb,
 		rra.ConfiRepProb, rra.ConfiPrdProb, rra.ConfiFinProb,
 		rra.IntegRepProb, rra.IntegPrdProb, rra.IntegFinProb,
-		rra.DefData, rra.LastUpdated, buf,
+		rra.DefData, rra.LastUpdated, raw,
 		rra.Name, rra.LastUpdated)
-	if err != nil {
-		op.logf(err.Error())
-		http.Error(rw, "error processing rra", 500)
-		return
-	}
+	return err
 }
 
 // serviceGetRRA is the API entry point to retrieve a specific RRA. All details

--- a/serviceapi/rra_test.go
+++ b/serviceapi/rra_test.go
@@ -154,6 +154,9 @@ func TestServiceRRAs(t *testing.T) {
 		}
 		cnt++
 	}
+	// Also add one here, since we should have the reference service present in
+	// the database
+	cnt++
 	buf, err := ioutil.ReadAll(rr.Body)
 	if err != nil {
 		t.Fatalf("ioutil.ReadAll: %v", err)

--- a/serviceapi/serviceapi.go
+++ b/serviceapi/serviceapi.go
@@ -261,6 +261,13 @@ func main() {
 			time.Sleep(sd)
 		}
 	}()
+	go func() {
+		logf("spawning reference service update routine")
+		for {
+			referenceUpdate()
+			time.Sleep(1 * time.Minute)
+		}
+	}()
 
 	logf("Starting processing")
 

--- a/serviceapi/serviceapi_test.go
+++ b/serviceapi/serviceapi_test.go
@@ -144,6 +144,18 @@ func TestMain(m *testing.M) {
 			os.Exit(1)
 		}
 	}
+	// Also call the reference related routines, we will call them twice to validate
+	// continuous execution
+	err = referenceService()
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "%v\n", err)
+		os.Exit(1)
+	}
+	err = referenceService()
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "%v\n", err)
+		os.Exit(1)
+	}
 
 	// Run the interlink rules prior to the other tests
 	rules, err := interlinkLoadRules()

--- a/serviceapi/testdata/interlink.rules
+++ b/serviceapi/testdata/interlink.rules
@@ -17,3 +17,8 @@ host matches testhost\d\..* ownership operator testservice
 
 host matches anothertesthost.* ownership operator anothertestservice
 host matches triagekey.* ownership operator anothertestservice triagekey
+
+add assetgroup reference
+host matches referencehost.* link assetgroup reference
+website matches referencewww.* link assetgroup reference
+assetgroup matches reference link service ^Reference\sservice


### PR DESCRIPTION
serviceapi periodically updates a reference service in the database,
that provides all possible known indicator values. This service is
returned with risk documents, and would typically be filtered before
displaying it in a normal case.