### PR TITLE
add support to pull specific indicator data for all assets

### DIFF
--- a/serviceapi/serviceapi.go
+++ b/serviceapi/serviceapi.go
@@ -285,6 +285,7 @@ func muxRouter() *mux.Router {
 	r := mux.NewRouter()
 	s := r.PathPrefix("/api/v1").Subrouter()
 	s.HandleFunc("/indicator", authenticate(serviceIndicator, authWriteIndicator)).Methods("POST")
+	s.HandleFunc("/indicators", authenticate(serviceGetIndicators, authReadRisk)).Methods("GET")
 	s.HandleFunc("/assetgroups", authenticate(serviceAssetGroups, authReadRisk)).Methods("GET")
 	s.HandleFunc("/assetgroup/id", authenticate(serviceGetAssetGroup, authReadRisk)).Methods("GET")
 	s.HandleFunc("/rras", authenticate(serviceRRAs, authReadRisk)).Methods("GET")


### PR DESCRIPTION
Adds an endpoint that can be used to request indicator data for a
specific event source type, returning the most recent indicators of the
type for all applicable assets.