### PR TITLE
Add claudijd SSH keys for remote troubleshooting

### DIFF
--- a/cloudformation/us-west-2.yml
+++ b/cloudformation/us-west-2.yml
@@ -15,7 +15,7 @@ Parameters:
   SSHKeyName:
     Description: Name of SSH key to use for instances
     Type: String
-    Default: alm-keys
+    Default: claudijd-keys
 Mappings:
   prod:
     us-west-2:


### PR DESCRIPTION
There is an issue with service api returning errors on one of the routes we get risk data from.  This simply removes alm's access and adds my own so I can look into what's going on and fix the immediate issue.