### PR TITLE
Change from using a certificateName to a certificateArn

### DIFF
--- a/config.dev.yml
+++ b/config.dev.yml
@@ -1,6 +1,6 @@
 DOMAIN_NAME: serviceapi.security.allizom.org
 ZONE_ID: Z13VQZ50081YZU
-CERTIFICATE_NAME: serviceapi.security.allizom.org
+CERTIFICATE_ARN: arn:aws:acm:us-west-2:656532927350:certificate/436a9e26-6fc9-496d-a383-53b7c144e21a
 AUTH0_URL: auth-dev.mozilla.auth0.com
 AUDIENCE: https://serviceapi.security.allizom.org/
 ENVIRONMENT: dev

--- a/config.prod.yml
+++ b/config.prod.yml
@@ -1,6 +1,6 @@
 DOMAIN_NAME: serviceapi.security.mozilla.org
 ZONE_ID:  ZBALOKPGJTQW
-CERTIFICATE_NAME: serviceapi.security.mozilla.org
+CERTIFICATE_ARN: arn:aws:acm:us-west-2:371522382791:certificate/77e8a1bd-8f66-455d-99a3-261c64c661ec
 AUTH0_URL: auth.mozilla.auth0.com
 AUDIENCE: https://serviceapi.security.mozilla.org/
 ENVIRONMENT: prod

--- a/serverless.yml
+++ b/serverless.yml
@@ -15,7 +15,7 @@ custom:
     stage: ${self:provider.stage}
     createRoute53Record: true
     hostedZoneId:  ${file(config.${self:provider.stage}.yml):ZONE_ID}
-    certificateName: ${file(config.${self:provider.stage}.yml):CERTIFICATE_NAME}
+    certificateArn: ${file(config.${self:provider.stage}.yml):CERTIFICATE_ARN}
     endpointType: "regional"
     enabled: true
 


### PR DESCRIPTION
This will allow us to select a specific certificate deterministically
and will facilitate moving from a email verified ACM cert to a Route53
DNS based verification

The new ARNs in this commit are certs that are DNS verified
https://github.com/amplify-education/serverless-domain-manager/blob/4c58dbf42b07d5daadfdc5b5ad6439c4453adc99/index.js#L361-L364

See https://bugzilla.mozilla.org/show_bug.cgi?id=1515362